### PR TITLE
Add interactive path editor with maplibre-gl-draw

### DIFF
--- a/src/lib/components/PathEditor.svelte
+++ b/src/lib/components/PathEditor.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import MapboxDraw from 'maplibre-gl-draw';
+  import 'maplibre-gl-draw/dist/mapbox-gl-draw.css';
+  import type { Map } from 'maplibre-gl';
+  import { mapStore } from '$lib/stores/map';
+  import { pathStore } from '$lib/stores/pathStore';
+
+  let draw: MapboxDraw | null = null;
+  let map: Map | undefined;
+
+  function initialize(m: Map) {
+    draw = new MapboxDraw({
+      displayControlsDefault: false,
+      defaultMode: 'draw_line_string'
+    });
+    (m as any).addControl(draw);
+
+    const syncPath = () => {
+      const data = draw!.getAll();
+      if (data.features.length > 0) {
+        pathStore.set(data.features[0].geometry as GeoJSON.LineString);
+      } else {
+        pathStore.set(null);
+      }
+    };
+
+    m.on('draw.create', (e) => {
+      const id = e.features[0].id as string;
+      const all = draw!.getAll().features;
+      all.forEach((f) => {
+        if (f.id !== id) draw!.delete(f.id as string);
+      });
+      syncPath();
+    });
+    m.on('draw.update', syncPath);
+    m.on('draw.delete', syncPath);
+    m.on('draw.modechange', (e) => {
+      if (e.mode === 'draw_line_string') {
+        draw!.deleteAll();
+        pathStore.set(null);
+      }
+    });
+  }
+
+  function startNewPath() {
+    if (!draw) return;
+    draw.deleteAll();
+    pathStore.set(null);
+    draw.changeMode('draw_line_string');
+  }
+
+  onMount(() => {
+    const unsubscribe = mapStore.subscribe((m) => {
+      map = m;
+      if (map && !draw) {
+        initialize(map);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      if (map && draw) {
+        (map as any).removeControl(draw);
+      }
+      draw = null;
+    };
+  });
+</script>
+
+<div class="space-y-2">
+  <button class="px-2 py-1 bg-blue-500 text-white rounded" on:click={startNewPath}>
+    Neuen Pfad zeichnen
+  </button>
+</div>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 export { default as Map } from './components/Map.svelte';
 export { default as LayerControl } from './components/LayerControl.svelte';
 export { default as GpxUpload } from './components/GpxUpload.svelte';
+export { default as PathEditor } from './components/PathEditor.svelte';

--- a/src/lib/stores/pathStore.ts
+++ b/src/lib/stores/pathStore.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const pathStore = writable<GeoJSON.LineString | null>(null);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Map, LayerControl, GpxUpload } from '$lib';
+  import { Map, LayerControl, GpxUpload, PathEditor } from '$lib';
   import type maplibregl from 'maplibre-gl';
   let map: maplibregl.Map | undefined;
 </script>
@@ -8,6 +8,7 @@
   <aside class="w-64 p-4 bg-white/80 overflow-y-auto space-y-4">
     <GpxUpload />
     <LayerControl />
+    <PathEditor />
   </aside>
   <div class="flex-1">
     <Map bind:map />


### PR DESCRIPTION
## Summary
- add PathEditor component that attaches maplibre-gl-draw to draw and edit a single path
- store path coordinates in a reactive Svelte store
- expose PathEditor and include it in the sidebar

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890747270b4832a9f177fce7966433b