### PR TITLE
feat: add 3D model configuration controls

### DIFF
--- a/src/lib/components/ModelControls.svelte
+++ b/src/lib/components/ModelControls.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { modelConfigStore } from '$lib/stores/modelConfigStore';
+
+  const scales = [500, 1000, 2500, 5000];
+
+  let scale = 500;
+  let baseHeight = 0;
+  let buildingHeightMultiplier = 1;
+  let elements = {
+    buildings: true,
+    roads: true,
+    water: true,
+    green: true
+  };
+
+  const unsubscribe = modelConfigStore.subscribe((value) => {
+    scale = value.scale;
+    baseHeight = value.baseHeight;
+    buildingHeightMultiplier = value.buildingHeightMultiplier;
+    elements = { ...value.elements };
+  });
+
+  onDestroy(unsubscribe);
+
+  function updateStore() {
+    modelConfigStore.set({
+      scale,
+      baseHeight,
+      buildingHeightMultiplier,
+      elements: { ...elements }
+    });
+  }
+</script>
+
+<div class="space-y-4">
+  <div>
+    <label class="block text-sm font-medium mb-1" for="scaleSelect">Maßstab</label>
+    <select
+      id="scaleSelect"
+      class="w-full border p-1"
+      bind:value={scale}
+      on:change={updateStore}
+    >
+      {#each scales as s}
+        <option value={s}>1:{s}</option>
+      {/each}
+    </select>
+  </div>
+
+  <div>
+    <label class="block text-sm font-medium mb-1" for="baseHeight">Basishöhe (m)</label>
+    <input
+      id="baseHeight"
+      type="number"
+      min="-100"
+      max="100"
+      class="w-full border p-1"
+      bind:value={baseHeight}
+      on:input={updateStore}
+    />
+  </div>
+
+  <div>
+    <label
+      class="block text-sm font-medium mb-1"
+      for="heightMultiplier"
+      >Gebäudehöhe-Multiplikator: {buildingHeightMultiplier}</label
+    >
+    <input
+      id="heightMultiplier"
+      type="range"
+      min="0.5"
+      max="3"
+      step="0.1"
+      class="w-full"
+      bind:value={buildingHeightMultiplier}
+      on:input={updateStore}
+    />
+  </div>
+
+  <fieldset>
+    <legend class="block text-sm font-medium mb-1">Elementauswahl</legend>
+    <div class="space-y-1">
+      <label class="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          bind:checked={elements.buildings}
+          on:change={updateStore}
+        />
+        <span>Gebäude</span>
+      </label>
+      <label class="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          bind:checked={elements.roads}
+          on:change={updateStore}
+        />
+        <span>Straßen</span>
+      </label>
+      <label class="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          bind:checked={elements.water}
+          on:change={updateStore}
+        />
+        <span>Gewässer</span>
+      </label>
+      <label class="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          bind:checked={elements.green}
+          on:change={updateStore}
+        />
+        <span>Grünflächen</span>
+      </label>
+    </div>
+  </fieldset>
+</div>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,4 @@ export { default as Map } from './components/Map.svelte';
 export { default as LayerControl } from './components/LayerControl.svelte';
 export { default as GpxUpload } from './components/GpxUpload.svelte';
 export { default as PathEditor } from './components/PathEditor.svelte';
+export { default as ModelControls } from './components/ModelControls.svelte';

--- a/src/lib/stores/modelConfigStore.ts
+++ b/src/lib/stores/modelConfigStore.ts
@@ -1,0 +1,27 @@
+import { writable } from 'svelte/store';
+
+export interface ModelElements {
+  buildings: boolean;
+  roads: boolean;
+  water: boolean;
+  green: boolean;
+}
+
+export interface ModelConfig {
+  scale: number;
+  baseHeight: number;
+  buildingHeightMultiplier: number;
+  elements: ModelElements;
+}
+
+export const modelConfigStore = writable<ModelConfig>({
+  scale: 500,
+  baseHeight: 0,
+  buildingHeightMultiplier: 1,
+  elements: {
+    buildings: true,
+    roads: true,
+    water: true,
+    green: true
+  }
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Map, LayerControl, GpxUpload, PathEditor } from '$lib';
+  import { Map, LayerControl, GpxUpload, PathEditor, ModelControls } from '$lib';
   import type maplibregl from 'maplibre-gl';
   let map: maplibregl.Map | undefined;
 </script>
@@ -9,6 +9,7 @@
     <GpxUpload />
     <LayerControl />
     <PathEditor />
+    <ModelControls />
   </aside>
   <div class="flex-1">
     <Map bind:map />


### PR DESCRIPTION
## Summary
- add model configuration store
- implement ModelControls component with scale, base height, height multiplier and element selection bound to store
- wire new control panel into side panel and exports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68908088de74832a9be26baaf8f99715