### PR TITLE
feat: add three.js viewer component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
 			"dependencies": {
 				"gpx-parser-builder": "^1.1.1",
 				"maplibre-gl": "^5.6.1",
-				"maplibre-gl-draw": "^1.6.9"
+				"maplibre-gl-draw": "^1.6.9",
+				"three": "^0.179.1"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^6.0.0",
 				"@sveltejs/kit": "^2.22.0",
 				"@sveltejs/vite-plugin-svelte": "^6.0.0",
+				"@types/three": "^0.178.1",
 				"autoprefixer": "^10.4.21",
 				"postcss": "^8.5.6",
 				"svelte": "^5.0.0",
@@ -51,6 +53,13 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/@dimforge/rapier3d-compat": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+			"integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.8",
@@ -2598,6 +2607,13 @@
 				"d3-voronoi": "1.1.2"
 			}
 		},
+		"node_modules/@tweenjs/tween.js": {
+			"version": "23.1.3",
+			"resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+			"integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -2673,6 +2689,13 @@
 			"integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
 			"license": "MIT"
 		},
+		"node_modules/@types/stats.js": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+			"integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/supercluster": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
@@ -2682,6 +2705,29 @@
 				"@types/geojson": "*"
 			}
 		},
+		"node_modules/@types/three": {
+			"version": "0.178.1",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.178.1.tgz",
+			"integrity": "sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@dimforge/rapier3d-compat": "~0.12.0",
+				"@tweenjs/tween.js": "~23.1.3",
+				"@types/stats.js": "*",
+				"@types/webxr": "*",
+				"@webgpu/types": "*",
+				"fflate": "~0.8.2",
+				"meshoptimizer": "~0.18.1"
+			}
+		},
+		"node_modules/@types/webxr": {
+			"version": "0.5.22",
+			"resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+			"integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/xml2js": {
 			"version": "0.4.14",
 			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
@@ -2690,6 +2736,13 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@webgpu/types": {
+			"version": "0.1.64",
+			"resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+			"integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
@@ -3659,6 +3712,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
@@ -4860,6 +4920,13 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/meshoptimizer": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+			"integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -6289,6 +6356,12 @@
 			"engines": {
 				"node": ">=0.8"
 			}
+		},
+		"node_modules/three": {
+			"version": "0.179.1",
+			"resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+			"integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
+			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
+		"@types/three": "^0.178.1",
 		"autoprefixer": "^10.4.21",
 		"postcss": "^8.5.6",
 		"svelte": "^5.0.0",
@@ -26,6 +27,7 @@
 	"dependencies": {
 		"gpx-parser-builder": "^1.1.1",
 		"maplibre-gl": "^5.6.1",
-		"maplibre-gl-draw": "^1.6.9"
+		"maplibre-gl-draw": "^1.6.9",
+		"three": "^0.179.1"
 	}
 }

--- a/src/lib/components/Viewer.svelte
+++ b/src/lib/components/Viewer.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import * as THREE from 'three';
+  import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+  import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+  import { onMount } from 'svelte';
+  import { modelConfigStore } from '$lib/stores/modelConfigStore';
+  import type { ModelConfig } from '$lib/stores/modelConfigStore';
+
+  let container: HTMLDivElement;
+  let renderer: THREE.WebGLRenderer;
+  let camera: THREE.PerspectiveCamera;
+  let scene: THREE.Scene;
+  let controls: OrbitControls;
+  let modelGroup: THREE.Group = new THREE.Group();
+  let ground: THREE.Object3D | undefined;
+
+  async function loadModel(cfg: ModelConfig) {
+    try {
+      const elements = Object.entries(cfg.elements)
+        .filter(([, v]) => v)
+        .map(([k]) => k);
+      const res = await fetch('/api/model', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          scale: cfg.scale,
+          baseHeight: cfg.baseHeight,
+          buildingMultiplier: cfg.buildingHeightMultiplier,
+          elements
+        })
+      });
+      const data = await res.json();
+      buildScene(data.features, cfg.baseHeight);
+    } catch (err) {
+      console.error('failed to load model', err);
+    }
+  }
+
+  function clearGroup(group: THREE.Group) {
+    group.traverse((obj: THREE.Object3D) => {
+      if (obj instanceof THREE.Mesh) {
+        obj.geometry.dispose();
+        if (Array.isArray(obj.material)) {
+          obj.material.forEach((m: THREE.Material) => m.dispose());
+        } else {
+          (obj.material as THREE.Material).dispose();
+        }
+      }
+    });
+    group.clear();
+  }
+
+  interface Feature {
+    geometry: [number, number, number][];
+    height: number;
+    type: 'building' | 'road' | 'water';
+  }
+
+  function buildScene(features: Feature[], baseHeight: number) {
+    clearGroup(modelGroup);
+    if (ground) {
+      scene.remove(ground);
+      ground = undefined;
+    }
+
+    const geoms: Record<string, THREE.BufferGeometry[]> = {
+      building: [],
+      road: [],
+      water: []
+    };
+
+    for (const f of features) {
+      const pts = f.geometry.map(([x, _y, z]) => new THREE.Vector2(x, z));
+      if (pts.length < 3) continue;
+      if (!pts[0].equals(pts[pts.length - 1])) pts.push(pts[0]);
+      const shape = new THREE.Shape(pts);
+      const geom = new THREE.ExtrudeGeometry(shape, {
+        depth: f.height || 0.1,
+        bevelEnabled: false
+      });
+      geom.rotateX(-Math.PI / 2);
+      geom.translate(0, baseHeight, 0);
+      geoms[f.type]?.push(geom);
+    }
+
+    const materials: Record<string, THREE.Material> = {
+      building: new THREE.MeshStandardMaterial({ color: 0xb0b0b0 }),
+      road: new THREE.MeshStandardMaterial({ color: 0x666666 }),
+      water: new THREE.MeshStandardMaterial({ color: 0x3399ff })
+    };
+
+    for (const type of Object.keys(geoms)) {
+      const g = geoms[type];
+      if (!g.length) continue;
+      const merged = mergeBufferGeometries(g);
+      const mesh = new THREE.Mesh(merged, materials[type]);
+      modelGroup.add(mesh);
+    }
+
+    const box = new THREE.Box3().setFromObject(modelGroup);
+    const size = box.getSize(new THREE.Vector3()).length();
+    const sphere = box.getBoundingSphere(new THREE.Sphere());
+    if (sphere && isFinite(sphere.radius)) {
+      camera.position.set(
+        sphere.center.x + sphere.radius * 2,
+        sphere.center.y + sphere.radius * 2,
+        sphere.center.z + sphere.radius * 2
+      );
+      controls.target.copy(sphere.center);
+      controls.update();
+    }
+
+    const gridSize = size || 100;
+    const grid = new THREE.GridHelper(gridSize, 20);
+    grid.position.y = baseHeight;
+    ground = grid;
+    scene.add(grid);
+  }
+
+  function onResize() {
+    if (!container) return;
+    camera.aspect = container.clientWidth / container.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+  }
+
+  function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+    renderer.render(scene, camera);
+  }
+
+  onMount(() => {
+    scene = new THREE.Scene();
+    scene.add(modelGroup);
+
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    camera = new THREE.PerspectiveCamera(
+      60,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      10000
+    );
+
+    controls = new OrbitControls(camera, renderer.domElement);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.8));
+    const dir = new THREE.DirectionalLight(0xffffff, 0.5);
+    dir.position.set(50, 100, 50);
+    scene.add(dir);
+
+    const unsub = modelConfigStore.subscribe((cfg) => loadModel(cfg));
+
+    window.addEventListener('resize', onResize);
+    animate();
+
+    return () => {
+      unsub();
+      window.removeEventListener('resize', onResize);
+      controls.dispose();
+      renderer.dispose();
+    };
+  });
+</script>
+
+<div bind:this={container} class="w-full h-full"></div>
+

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,3 +3,4 @@ export { default as LayerControl } from './components/LayerControl.svelte';
 export { default as GpxUpload } from './components/GpxUpload.svelte';
 export { default as PathEditor } from './components/PathEditor.svelte';
 export { default as ModelControls } from './components/ModelControls.svelte';
+export { default as Viewer } from './components/Viewer.svelte';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
-  import { Map, LayerControl, GpxUpload, PathEditor, ModelControls } from '$lib';
+  import { Map, LayerControl, GpxUpload, PathEditor, ModelControls, Viewer } from '$lib';
   import type maplibregl from 'maplibre-gl';
   let map: maplibregl.Map | undefined;
+  let showViewer = false;
 </script>
 
-<div class="flex w-full h-screen">
-  <aside class="w-64 p-4 bg-white/80 overflow-y-auto space-y-4">
-    <GpxUpload />
-    <LayerControl />
-    <PathEditor />
-    <ModelControls />
-  </aside>
-  <div class="flex-1">
-    <Map bind:map />
+  <div class="flex w-full h-screen">
+    <aside class="w-64 p-4 bg-white/80 overflow-y-auto space-y-4">
+      <GpxUpload />
+      <LayerControl />
+      <PathEditor />
+      <ModelControls />
+      <button
+        class="w-full p-2 bg-blue-600 text-white"
+        on:click={() => (showViewer = !showViewer)}
+      >
+        {showViewer ? '2D Karte' : '3D Ansicht'}
+      </button>
+    </aside>
+    <div class="flex-1 relative">
+      {#if showViewer}
+        <Viewer />
+      {:else}
+        <Map bind:map />
+      {/if}
+    </div>
   </div>
-</div>

--- a/src/types/three-extras.d.ts
+++ b/src/types/three-extras.d.ts
@@ -1,0 +1,7 @@
+declare module 'three/examples/jsm/utils/BufferGeometryUtils.js' {
+  import { BufferGeometry } from 'three';
+  export function mergeBufferGeometries(
+    geometries: BufferGeometry[],
+    useGroups?: boolean
+  ): BufferGeometry;
+}


### PR DESCRIPTION
## Summary
- add Three.js-based Viewer component to render extruded model data
- toggle between 2D map and 3D viewer in main page
- include three.js and type declarations

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689093929658832a9aa873917e1df28e