### PR TITLE
feat: add rectangle selection and bbox query

### DIFF
--- a/src/lib/components/BBoxEditor.svelte
+++ b/src/lib/components/BBoxEditor.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { mapStore } from '$lib/stores/map';
+  import { bboxStore } from '$lib/stores/bboxStore';
+  import { LngLatBounds, type Map as MaplibreMap, type MapMouseEvent } from 'maplibre-gl';
+
+  let map: MaplibreMap | undefined;
+  let isDrawing = false;
+  let start: [number, number] | null = null;
+
+  function boundsToPolygon(bounds: LngLatBounds): GeoJSON.Polygon {
+    const sw = bounds.getSouthWest();
+    const ne = bounds.getNorthEast();
+    const nw = { lng: sw.lng, lat: ne.lat };
+    const se = { lng: ne.lng, lat: sw.lat };
+    return {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [sw.lng, sw.lat],
+          [nw.lng, nw.lat],
+          [ne.lng, ne.lat],
+          [se.lng, se.lat],
+          [sw.lng, sw.lat]
+        ]
+      ]
+    };
+  }
+
+  function updateSource(poly: GeoJSON.Polygon) {
+    if (!map) return;
+    const data: GeoJSON.Feature<GeoJSON.Polygon> = { type: 'Feature', geometry: poly, properties: {} };
+    const source = map.getSource('bbox') as maplibregl.GeoJSONSource | undefined;
+    if (source) {
+      source.setData(data);
+    } else {
+      map.addSource('bbox', { type: 'geojson', data });
+      map.addLayer({ id: 'bbox-fill', type: 'fill', source: 'bbox', paint: { 'fill-color': '#088', 'fill-opacity': 0.1 } });
+      map.addLayer({ id: 'bbox-line', type: 'line', source: 'bbox', paint: { 'line-color': '#088', 'line-width': 2 } });
+    }
+  }
+
+  function clearBox() {
+    if (!map) return;
+    if (map.getLayer('bbox-fill')) map.removeLayer('bbox-fill');
+    if (map.getLayer('bbox-line')) map.removeLayer('bbox-line');
+    if (map.getSource('bbox')) map.removeSource('bbox');
+    bboxStore.set(null);
+  }
+
+  function startDrawing() {
+    if (!map) return;
+    isDrawing = true;
+    map.getCanvas().style.cursor = 'crosshair';
+
+    const onMouseDown = (e: MapMouseEvent) => {
+      start = [e.lngLat.lng, e.lngLat.lat];
+      map!.dragPan.disable();
+
+      const onMove = (ev: MapMouseEvent) => {
+        const bounds = new LngLatBounds(start!, [ev.lngLat.lng, ev.lngLat.lat]);
+        updateSource(boundsToPolygon(bounds));
+      };
+
+      const onUp = (ev: MapMouseEvent) => {
+        const bounds = new LngLatBounds(start!, [ev.lngLat.lng, ev.lngLat.lat]);
+        updateSource(boundsToPolygon(bounds));
+        bboxStore.set([
+          bounds.getSouth(),
+          bounds.getWest(),
+          bounds.getNorth(),
+          bounds.getEast()
+        ]);
+        map!.getCanvas().style.cursor = '';
+        map!.off('mousemove', onMove);
+        map!.off('mouseup', onUp);
+        map!.dragPan.enable();
+        isDrawing = false;
+      };
+
+      map!.on('mousemove', onMove);
+      map!.on('mouseup', onUp);
+    };
+
+    map.once('mousedown', onMouseDown);
+  }
+
+  onMount(() => {
+    const unsubscribe = mapStore.subscribe((m) => {
+      map = m;
+    });
+    return () => unsubscribe();
+  });
+</script>
+
+<div class="space-y-2">
+  <button class="px-2 py-1 bg-blue-500 text-white rounded" on:click={startDrawing} disabled={isDrawing}>
+    Rechteck zeichnen
+  </button>
+  <button class="px-2 py-1 bg-gray-300 rounded" on:click={clearBox}>
+    Löschen
+  </button>
+</div>

--- a/src/lib/components/Viewer.svelte
+++ b/src/lib/components/Viewer.svelte
@@ -6,6 +6,7 @@
   import { onMount } from 'svelte';
   import { modelConfigStore } from '$lib/stores/modelConfigStore';
   import type { ModelConfig } from '$lib/stores/modelConfigStore';
+  import { bboxStore } from '$lib/stores/bboxStore';
 
   let container: HTMLDivElement;
   let renderer: THREE.WebGLRenderer;
@@ -15,6 +16,7 @@
   let modelGroup: THREE.Group = new THREE.Group();
   let ground: THREE.Object3D | undefined;
   let exportMessage: string | null = null;
+  let bbox: [number, number, number, number] | null = null;
 
   function exportModel(binary = false) {
     const exporter = new GLTFExporter();
@@ -60,7 +62,8 @@
           scale: cfg.scale,
           baseHeight: cfg.baseHeight,
           buildingMultiplier: cfg.buildingHeightMultiplier,
-          elements
+          elements,
+          bbox: bbox || undefined
         })
       });
       const data = await res.json();
@@ -187,12 +190,14 @@
     scene.add(dir);
 
     const unsub = modelConfigStore.subscribe((cfg) => loadModel(cfg));
+    const unsubBBox = bboxStore.subscribe((v) => (bbox = v));
 
     window.addEventListener('resize', onResize);
     animate();
 
     return () => {
       unsub();
+      unsubBBox();
       window.removeEventListener('resize', onResize);
       controls.dispose();
       renderer.dispose();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,3 +4,4 @@ export { default as GpxUpload } from './components/GpxUpload.svelte';
 export { default as PathEditor } from './components/PathEditor.svelte';
 export { default as ModelControls } from './components/ModelControls.svelte';
 export { default as Viewer } from './components/Viewer.svelte';
+export { default as BBoxEditor } from './components/BBoxEditor.svelte';

--- a/src/lib/stores/bboxStore.ts
+++ b/src/lib/stores/bboxStore.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+
+// Stores bounding box as [south, west, north, east]
+export const bboxStore = writable<[number, number, number, number] | null>(null);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { Map, LayerControl, GpxUpload, PathEditor, ModelControls, Viewer } from '$lib';
+  import {
+    Map,
+    LayerControl,
+    GpxUpload,
+    PathEditor,
+    ModelControls,
+    Viewer,
+    BBoxEditor
+  } from '$lib';
   import type maplibregl from 'maplibre-gl';
   let map: maplibregl.Map | undefined;
   let showViewer = false;
@@ -10,6 +18,7 @@
       <GpxUpload />
       <LayerControl />
       <PathEditor />
+      <BBoxEditor />
       <ModelControls />
       <button
         class="w-full p-2 bg-blue-600 text-white"

--- a/src/routes/api/model/+server.ts
+++ b/src/routes/api/model/+server.ts
@@ -3,8 +3,12 @@ import type { RequestHandler } from '@sveltejs/kit';
 // simple in-memory cache for requests
 const CACHE = new Map<string, any>();
 
-function buildOverpassQuery(elements: string[], bbox?: number[]): string {
-  const bboxPart = bbox && bbox.length === 4 ? `(${bbox.join(',')})` : '';
+function buildOverpassQuery(
+  elements: string[],
+  bbox?: [number, number, number, number]
+): string {
+  // bbox expected as [south, west, north, east]
+  const bboxPart = bbox ? `(${bbox[0]},${bbox[1]},${bbox[2]},${bbox[3]})` : '';
   let query = '[out:json][timeout:25];(';
   if (elements.includes('buildings')) {
     query += `way["building"]${bboxPart};relation["building"]${bboxPart};`;


### PR DESCRIPTION
## Summary
- add bbox drawing tool and store
- forward bbox to viewer and API query
- include bbox in Overpass query builder

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890acc60f80832aae0475875c4cc82f