### PR TITLE
feat: extrude GPX paths in 3D viewer

### DIFF
--- a/src/lib/components/GpxUpload.svelte
+++ b/src/lib/components/GpxUpload.svelte
@@ -3,6 +3,7 @@
   import maplibregl from 'maplibre-gl';
   import GPX from 'gpx-parser-builder';
   import { mapStore } from '$lib/stores/map';
+  import { pathStore } from '$lib/stores/pathStore';
 
   let file: File | null = null;
 
@@ -25,14 +26,16 @@
       });
     });
     if (coords.length === 0) return;
+    const geometry: GeoJSON.LineString = {
+      type: 'LineString',
+      coordinates: coords
+    };
     const geojson = {
       type: 'Feature',
-      geometry: {
-        type: 'LineString',
-        coordinates: coords
-      },
+      geometry,
       properties: {}
     } as GeoJSON.Feature<GeoJSON.LineString>;
+    pathStore.set(geometry);
 
     const map = get(mapStore);
     if (!map) return;


### PR DESCRIPTION
## Summary
- extrude pathStore or GPX data into a TubeGeometry and render in the 3D viewer
- include path geometry in scene building and GLTF/GLB export
- update GPX upload to feed geometry into path store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890b16fd5f8832aa392317905e221a3