### PR TITLE
docs: add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,76 @@
-# sv
+# 3DMap
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+### 🧭 Projektübersicht
+- Beschreibung:  
+  Dieses Projekt ist eine interaktive Webanwendung zur Erstellung, Visualisierung und zum Export von 3D-Szenen basierend auf OpenStreetMap-Daten.
 
-## Creating a project
+- Hauptfunktionen:
+  - 2D-Karte mit MapLibre GL JS
+  - GPX-Import und Pfad-Zeichnung mit maplibre-gl-draw
+  - Dynamische OSM-Abfragen über die Overpass API
+  - Extrusion von Geometrien zu 3D-Modellen mit Three.js
+  - Parametergesteuertes Modell-UI (Maßstab, Höhe, Layerauswahl)
+  - Bounding-Box-Auswahl auf der Karte
+  - Export als `.gltf` und `.glb`
+  - Fehlerhandling im UI
+  - Tests für API und UI
 
-If you're seeing this, you've probably already done this step. Congrats!
+### 🚀 Schnellstart (lokale Entwicklung)
 
-```sh
-# create a new project in the current directory
-npx sv create
+#### Voraussetzungen
+- Node.js ≥ 18
+- npm oder pnpm
 
-# create a new project in my-app
-npx sv create my-app
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```sh
+#### Installation
+```bash
+npm install
 npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
 ```
 
-## Building
-
-To create a production version of your app:
-
-```sh
-npm run build
+#### Optional: Playwright vorbereiten
+```bash
+npx playwright install
 ```
 
-You can preview the production build with `npm run preview`.
+### 🐳 Docker (optional)
+> Hinweis: Eine vollständige Docker-Integration ist möglich (Dockerfile & docker-compose folgen).  
+> Damit kann das Projekt z. B. auf Proxmox, NAS oder VPS gehostet werden.
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+### 🧪 Tests
+
+#### Unit-Tests (z. B. Overpass-Abfrage, 3D-Konvertierung)
+```bash
+npx vitest run
+```
+
+#### UI-Tests (z. B. GPX-Upload, API-Fehler)
+```bash
+npx playwright test
+```
+
+### ⚙️ Architektur
+
+| Ordner / Datei                      | Beschreibung                                 |
+|------------------------------------|----------------------------------------------|
+| `src/lib/components/`              | Svelte-Komponenten (Map, Viewer, Upload...)  |
+| `src/lib/stores/`                  | Reactive Stores (z. B. Map, Pfad, Konfiguration) |
+| `src/routes/api/model/+server.ts` | Modell-API für Overpass & 3D-Erzeugung       |
+| `model-cache.json`                 | Persistenter Server-Cache für Overpass-Daten |
+
+### 📦 Exportformate
+- Unterstützte Formate: `.gltf`, `.glb`
+- Empfohlener Online-Viewer: [gltf-viewer.donmccurdy.com](https://gltf-viewer.donmccurdy.com/)
+- Export über Button im 3D-Viewer
+- Dateiname enthält Zeitstempel für Nachvollziehbarkeit
+
+### 📚 Verwendete Technologien
+- [SvelteKit](https://kit.svelte.dev/)
+- [MapLibre GL JS](https://maplibre.org/)
+- [Three.js](https://threejs.org/)
+- [Overpass API](https://overpass-api.de/)
+- [Turf.js](https://turfjs.org/)
+- [gpx-parser-builder](https://www.npmjs.com/package/gpx-parser-builder)
+- [maplibre-gl-draw](https://github.com/maplibre/maplibre-gl-draw)
+- [Vitest](https://vitest.dev/)
+- [Playwright](https://playwright.dev/)
+

--- a/todo.md
+++ b/todo.md
@@ -22,6 +22,8 @@ Phase 1: Fundament, Karten-Interface & Layer-Management
 
 [x] Projekt-Setup & Basiskonfiguration.
 
+[x] Erstellung der README.md.
+
 Initialisiere das SvelteKit-Projekt mit TypeScript und Tailwind CSS wie im ursprünglichen Plan.
 
 Installiere zusätzliche Bibliotheken: npm install gpx-parser-builder maplibre-gl-draw.


### PR DESCRIPTION
## Summary
- document project with full-featured README: overview, quick start, architecture, tech stack, and more
- note README completion in project TODO

## Testing
- `npm test` *(fails: missing Playwright browsers and system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6890c81cd878832aa4cdc14e545caf47