### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.vite
+dist
+*.log
+*.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "run", "preview"]

--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ npm run dev
 npx playwright install
 ```
 
-### 🐳 Docker (optional)
-> Hinweis: Eine vollständige Docker-Integration ist möglich (Dockerfile & docker-compose folgen).  
-> Damit kann das Projekt z. B. auf Proxmox, NAS oder VPS gehostet werden.
+### 🐳 Docker
+
+#### Build & Run
+```bash
+docker compose up --build
+```
 
 ### 🧪 Tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./model-cache.json:/app/model-cache.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "scripts": {
                 "dev": "vite dev",
                 "build": "vite build",
-                "preview": "vite preview",
+                "preview": "vite preview --host 0.0.0.0 --port 3000",
                 "prepare": "svelte-kit sync || echo ''",
                 "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
                 "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/todo.md
+++ b/todo.md
@@ -24,6 +24,8 @@ Phase 1: Fundament, Karten-Interface & Layer-Management
 
 [x] Erstellung der README.md.
 
+[x] Docker-Setup & Containerisierung.
+
 Initialisiere das SvelteKit-Projekt mit TypeScript und Tailwind CSS wie im ursprünglichen Plan.
 
 Installiere zusätzliche Bibliotheken: npm install gpx-parser-builder maplibre-gl-draw.


### PR DESCRIPTION
## Summary
- add Dockerfile for Node-based production build
- provide docker-compose setup and ignore files
- document container usage and mark TODO

## Testing
- `npm test` *(fails: Error: browserType.launch: Executable doesn't exist at ...; run `npx playwright install`)*
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890ca89fa2c832ab7016d4cceb7428c