### PR TITLE
docs: note ES module support

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -32,7 +32,9 @@ Phase 1: Fundament, Karten-Interface & Layer-Management
 
 Initialisiere das SvelteKit-Projekt mit TypeScript und Tailwind CSS wie im ursprünglichen Plan.
 
-Installiere zusätzliche Bibliotheken: npm install gpx-parser-builder maplibre-gl-draw.
+[x] Installiere zusätzliche Bibliotheken: npm install gpx-parser-builder maplibre-gl-draw.
+
+✔️ Unterstützung für ES-Module (type="module") aktiviert, um ESM-Bibliotheken zu importieren.
 
 [ ] Entwicklung der zentralen Karten-Komponente (Map.svelte).
 


### PR DESCRIPTION
## Summary
- document ES module support in TODO

## Testing
- `docker compose down` *(fails: 'compose' is not a docker command)*
- `docker-compose up --build` *(fails: Error while fetching server API version: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6890d81e0510832ab48994510e41100a