### PR TITLE
refactor: load maplibre-gl-draw only on client

### DIFF
--- a/src/lib/components/PathEditor.svelte
+++ b/src/lib/components/PathEditor.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import MapboxDraw from 'maplibre-gl-draw';
-  import 'maplibre-gl-draw/dist/mapbox-gl-draw.css';
+  import { browser } from '$app/environment';
+  import type MapboxDraw from 'maplibre-gl-draw';
   import type { Map } from 'maplibre-gl';
   import { mapStore } from '$lib/stores/map';
   import { pathStore } from '$lib/stores/pathStore';
 
+  let Draw: typeof MapboxDraw;
   let draw: MapboxDraw | null = null;
   let map: Map | undefined;
 
+  if (browser) {
+    import('maplibre-gl-draw').then(async (mod) => {
+      Draw = mod.default;
+      await import('maplibre-gl-draw/dist/mapbox-gl-draw.css');
+      if (map && !draw) {
+        initialize(map);
+      }
+    });
+  }
+
   function initialize(m: Map) {
-    draw = new MapboxDraw({
+    draw = new Draw({
       displayControlsDefault: false,
       defaultMode: 'draw_line_string'
     });
@@ -53,7 +64,7 @@
   onMount(() => {
     const unsubscribe = mapStore.subscribe((m) => {
       map = m;
-      if (map && !draw) {
+      if (map && !draw && Draw) {
         initialize(map);
       }
     });

--- a/todo.md
+++ b/todo.md
@@ -36,6 +36,8 @@ Initialisiere das SvelteKit-Projekt mit TypeScript und Tailwind CSS wie im urspr
 
 ✔️ Unterstützung für ES-Module (type="module") aktiviert, um ESM-Bibliotheken zu importieren.
 
+✔️ maplibre-gl-draw läuft nun clientseitig und ist SSR-kompatibel.
+
 [ ] Entwicklung der zentralen Karten-Komponente (Map.svelte).
 
 Initialisiere MapLibre GL JS mit einem flexiblen Vektor-Kartenstil (z.B. von Stadia Maps), der klar definierte Layer für Gebäude, Gewässer, Grünflächen (landuse=grass, natural=wood), Sandflächen (natural=sand) und Straßen enthält.


### PR DESCRIPTION
## Summary
- load `maplibre-gl-draw` dynamically in `PathEditor.svelte` and remove server-side import
- note SSR compatibility of `maplibre-gl-draw` in TODO

## Testing
- `npm run dev`
- `docker-compose down` *(fails: Error while fetching server API version)*
- `docker-compose up --build` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_6890ebc80fcc832a9f585cf607b034eb