### PR TITLE
fix: delay map manipulation until style loads

### DIFF
--- a/src/lib/components/BBoxEditor.svelte
+++ b/src/lib/components/BBoxEditor.svelte
@@ -3,6 +3,7 @@
   import { mapStore } from '$lib/stores/map';
   import { bboxStore } from '$lib/stores/bboxStore';
   import { LngLatBounds, type Map as MaplibreMap, type MapMouseEvent } from 'maplibre-gl';
+  import { onMapLoaded } from '$lib/utils/map';
 
   let map: MaplibreMap | undefined;
   let isDrawing = false;
@@ -29,15 +30,33 @@
 
   function updateSource(poly: GeoJSON.Polygon) {
     if (!map) return;
-    const data: GeoJSON.Feature<GeoJSON.Polygon> = { type: 'Feature', geometry: poly, properties: {} };
-    const source = map.getSource('bbox') as maplibregl.GeoJSONSource | undefined;
-    if (source) {
-      source.setData(data);
-    } else {
-      map.addSource('bbox', { type: 'geojson', data });
-      map.addLayer({ id: 'bbox-fill', type: 'fill', source: 'bbox', paint: { 'fill-color': '#088', 'fill-opacity': 0.1 } });
-      map.addLayer({ id: 'bbox-line', type: 'line', source: 'bbox', paint: { 'line-color': '#088', 'line-width': 2 } });
-    }
+    const m = map;
+    const run = () => {
+      const data: GeoJSON.Feature<GeoJSON.Polygon> = {
+        type: 'Feature',
+        geometry: poly,
+        properties: {}
+      };
+      const source = m.getSource('bbox') as maplibregl.GeoJSONSource | undefined;
+      if (source) {
+        source.setData(data);
+      } else {
+        m.addSource('bbox', { type: 'geojson', data });
+        m.addLayer({
+          id: 'bbox-fill',
+          type: 'fill',
+          source: 'bbox',
+          paint: { 'fill-color': '#088', 'fill-opacity': 0.1 }
+        });
+        m.addLayer({
+          id: 'bbox-line',
+          type: 'line',
+          source: 'bbox',
+          paint: { 'line-color': '#088', 'line-width': 2 }
+        });
+      }
+    };
+    onMapLoaded(m, run);
   }
 
   function clearBox() {

--- a/src/lib/components/GpxUpload.svelte
+++ b/src/lib/components/GpxUpload.svelte
@@ -5,6 +5,7 @@
   import { browser } from '$app/environment';
   import { mapStore } from '$lib/stores/map';
   import { pathStore } from '$lib/stores/pathStore';
+  import { onMapLoaded } from '$lib/utils/map';
 
   let file: File | null = null;
   let error: string | null = null;
@@ -45,31 +46,33 @@
       const map = get(mapStore);
       if (!map) return;
 
-      const sourceId = 'gpx-track';
-      const layerId = 'gpx-track-line';
-      const existing = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
-      if (existing) {
-        existing.setData(geojson);
-      } else {
-        map.addSource(sourceId, { type: 'geojson', data: geojson });
-      }
-      if (!map.getLayer(layerId)) {
-        map.addLayer({
-          id: layerId,
-          type: 'line',
-          source: sourceId,
-          paint: {
-            'line-color': '#ff0000',
-            'line-width': 4
-          }
-        });
-      }
+      onMapLoaded(map, () => {
+        const sourceId = 'gpx-track';
+        const layerId = 'gpx-track-line';
+        const existing = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+        if (existing) {
+          existing.setData(geojson);
+        } else {
+          map.addSource(sourceId, { type: 'geojson', data: geojson });
+        }
+        if (!map.getLayer(layerId)) {
+          map.addLayer({
+            id: layerId,
+            type: 'line',
+            source: sourceId,
+            paint: {
+              'line-color': '#ff0000',
+              'line-width': 4
+            }
+          });
+        }
 
-      const bounds = coords.reduce(
-        (b, coord) => b.extend(coord as [number, number]),
-        new maplibregl.LngLatBounds(coords[0], coords[0])
-      );
-      map.fitBounds(bounds, { padding: 20 });
+        const bounds = coords.reduce(
+          (b, coord) => b.extend(coord as [number, number]),
+          new maplibregl.LngLatBounds(coords[0], coords[0])
+        );
+        map.fitBounds(bounds, { padding: 20 });
+      });
     } catch (err) {
       console.error('failed to process GPX', err);
       error = 'GPX-Datei konnte nicht geladen werden';

--- a/src/lib/components/LayerControl.svelte
+++ b/src/lib/components/LayerControl.svelte
@@ -3,6 +3,7 @@
   import { LAYERS } from '$lib/constants/layers';
   import { get } from 'svelte/store';
   import { onMount } from 'svelte';
+  import { onMapLoaded } from '$lib/utils/map';
 
   type LayerKey = keyof typeof LAYERS;
 
@@ -25,21 +26,25 @@
   function applyVisibility(key: LayerKey) {
     const map = get(mapStore);
     if (!map) return;
-    const def = LAYERS[key];
-    def.ids.forEach((id) =>
-      map.setLayoutProperty(id, 'visibility', visibility[key] ? 'visible' : 'none')
-    );
+    onMapLoaded(map, () => {
+      const def = LAYERS[key];
+      def.ids.forEach((id) =>
+        map.setLayoutProperty(id, 'visibility', visibility[key] ? 'visible' : 'none')
+      );
+    });
   }
 
   function applyDetailFilter() {
     const map = get(mapStore);
     if (!map) return;
-    Object.entries(LAYERS).forEach(([key, def]) => {
-      if (def.detailFilter) {
-        def.ids.forEach((id) => {
-          map.setFilter(id, reduceDetails ? def.detailFilter! : null);
-        });
-      }
+    onMapLoaded(map, () => {
+      Object.entries(LAYERS).forEach(([key, def]) => {
+        if (def.detailFilter) {
+          def.ids.forEach((id) => {
+            map.setFilter(id, reduceDetails ? def.detailFilter! : null);
+          });
+        }
+      });
     });
   }
 

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -25,11 +25,13 @@
       zoom
     });
 
-    // expose map instance via store for other components
-    mapStore.set(map);
+    map.on('style.load', () => {
+      // expose map instance via store for other components
+      mapStore.set(map!);
 
-    map.addControl(new maplibregl.NavigationControl(), 'top-right');
-    map.addControl(new maplibregl.ScaleControl());
+      map!.addControl(new maplibregl.NavigationControl(), 'top-right');
+      map!.addControl(new maplibregl.ScaleControl());
+    });
 
     return () => {
       mapStore.set(undefined);

--- a/src/lib/utils/map.ts
+++ b/src/lib/utils/map.ts
@@ -1,0 +1,9 @@
+import type maplibregl from 'maplibre-gl';
+
+export function onMapLoaded(map: maplibregl.Map, cb: () => void): void {
+  if (map.isStyleLoaded()) {
+    cb();
+  } else {
+    map.once('style.load', cb);
+  }
+}


### PR DESCRIPTION
## Summary
- expose map instance only after `style.load` and add controls within event
- add helper to run map actions once style is loaded
- defer layer and layout changes in GPX upload, bbox editor and layer control until style ready

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npm run check` *(fails: Module '"three/examples/jsm/utils/BufferGeometryUtils.js"' has no exported member 'mergeGeometries')*


------
https://chatgpt.com/codex/tasks/task_e_689101531578832ab89c461cb1390bd3