### PR TITLE
Add STL export option and download feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ und dieses Projekt verwendet [SemVer](https://semver.org/lang/de/) für die Vers
 - Overpass-Abfragen für gezeichnete Polygone
 - Clientseitige Konvertierung von OSM-Daten in 3D-Geometrien
 - Viewer rendert Modelle aus dem `modelStore` mit farbigen Materialien
+- Export von Modellen als GLTF, GLB und STL mit Dateinamenvorschlag und Nutzerfeedback
 
 ---
 

--- a/todo.md
+++ b/todo.md
@@ -134,3 +134,4 @@ Die bestehende GLTFExporter-Logik kann beibehalten werden. Sie exportiert die ge
 [x] Feature: Logging und Feedback, wenn keine OSM-Daten geladen werden
 [x] Feature: Shape-Selector für Rechtecke und Kreise
 [x] Feature: Overpass-Abfrage für gezeichnete Polygone
+[x] Feature: STL-Export


### PR DESCRIPTION
## Summary
- add STL export alongside existing GLTF/GLB downloads with filename timestamps and success messages
- warn when no scene data is available for export
- document STL export feature in changelog and todo list

## Testing
- `npm run check` *(fails: Argument of type '{ geometry: number[][]; height: number; type: string; }[]' is not assignable to parameter of type 'Feature[]'.)*
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689223ab29a4832a9650c16e6320cafb