### PR TITLE
feat: add building extrusion rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ und dieses Projekt verwendet [SemVer](https://semver.org/lang/de/) für die Vers
 - Clientseitige Konvertierung von OSM-Daten in 3D-Geometrien
 - Viewer rendert Modelle aus dem `modelStore` mit farbigen Materialien
 - Export von Modellen als GLTF, GLB und STL mit Dateinamenvorschlag und Nutzerfeedback
+- Gebäudeextrusionen direkt auf der Karte
 
 ---
 

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -3,6 +3,10 @@
   import 'maplibre-gl/dist/maplibre-gl.css';
   import { onMount } from 'svelte';
   import { mapStore } from '$lib/stores/map';
+  import { shapeStore } from '$lib/stores/shapeStore';
+  import { modelConfigStore } from '$lib/stores/modelConfigStore';
+  import { get } from 'svelte/store';
+  import * as THREE from 'three';
 
   // Allow external binding to map instance for dynamic layer control
   export let map: maplibregl.Map | undefined;
@@ -16,6 +20,94 @@
   export let zoom: number = 5;
 
   let mapContainer: HTMLDivElement;
+  let extrudeGroup: THREE.Group = new THREE.Group();
+  let fetchTimer: ReturnType<typeof setTimeout> | null = null;
+  let layerReady = false;
+
+  function polygonToBBox(poly: GeoJSON.Polygon): [number, number, number, number] {
+    const coords = poly.coordinates[0];
+    let minLon = Infinity,
+      minLat = Infinity,
+      maxLon = -Infinity,
+      maxLat = -Infinity;
+    for (const [lon, lat] of coords) {
+      if (lon < minLon) minLon = lon;
+      if (lat < minLat) minLat = lat;
+      if (lon > maxLon) maxLon = lon;
+      if (lat > maxLat) maxLat = lat;
+    }
+    return [minLat, minLon, maxLat, maxLon];
+  }
+
+  function clearGroup(group: THREE.Group) {
+    group.traverse((obj) => {
+      if (obj instanceof THREE.Mesh) {
+        obj.geometry.dispose();
+        if (Array.isArray(obj.material)) {
+          obj.material.forEach((m) => m.dispose());
+        } else {
+          (obj.material as THREE.Material).dispose();
+        }
+      }
+    });
+    group.clear();
+  }
+
+  function renderExtrudedBuildings(features: any[] = []) {
+    clearGroup(extrudeGroup);
+    if (!features || features.length === 0) {
+      map?.triggerRepaint();
+      return;
+    }
+    for (const f of features) {
+      const pts: [number, number][] = f.geometry?.map((c: number[]) => [c[0], c[2]]);
+      if (!pts || pts.length < 3) continue;
+      const shape = new THREE.Shape();
+      pts.forEach(([lng, lat], idx) => {
+        const mc = maplibregl.MercatorCoordinate.fromLngLat({ lng, lat });
+        if (idx === 0) shape.moveTo(mc.x, mc.y);
+        else shape.lineTo(mc.x, mc.y);
+      });
+      const base = f.geometry?.[0]?.[1] ?? 0;
+      const extrudeHeight = (f.height ?? base) - base;
+      const geom = new THREE.ExtrudeGeometry(shape, {
+        depth: extrudeHeight,
+        bevelEnabled: false
+      });
+      const mat = new THREE.MeshStandardMaterial({ color: 0xffcc00 });
+      const mesh = new THREE.Mesh(geom, mat);
+      mesh.position.z = base;
+      extrudeGroup.add(mesh);
+    }
+    map?.triggerRepaint();
+  }
+
+  async function loadBuildings(shape: GeoJSON.Polygon | null) {
+    if (!shape) {
+      renderExtrudedBuildings([]);
+      return;
+    }
+    const bbox = polygonToBBox(shape);
+    const cfg = get(modelConfigStore);
+    try {
+      const res = await fetch('/api/model', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          elements: ['buildings'],
+          scale: 1,
+          baseHeight: cfg.baseHeight,
+          buildingMultiplier: cfg.buildingHeightMultiplier,
+          bbox
+        })
+      });
+      const data = await res.json();
+      renderExtrudedBuildings(data?.features ?? []);
+    } catch (err) {
+      console.error('failed to fetch model', err);
+      renderExtrudedBuildings([]);
+    }
+  }
 
   onMount(() => {
     map = new maplibregl.Map({
@@ -31,9 +123,44 @@
 
       map!.addControl(new maplibregl.NavigationControl(), 'top-right');
       map!.addControl(new maplibregl.ScaleControl());
+
+      const customLayer = {
+        id: 'extruded-buildings',
+        type: 'custom' as const,
+        renderingMode: '3d' as const,
+        onAdd: function (_map: maplibregl.Map, gl: WebGLRenderingContext) {
+          const renderer = new THREE.WebGLRenderer({
+            canvas: _map.getCanvas(),
+            context: gl
+          });
+          renderer.autoClear = false;
+          ;(this as any).renderer = renderer;
+          ;(this as any).scene = new THREE.Scene();
+          ;(this as any).camera = new THREE.Camera();
+          ;(this as any).scene.add(extrudeGroup);
+        },
+        render: function (gl: WebGLRenderingContext, matrix: number[]) {
+          const camera = (this as any).camera as THREE.Camera;
+          const scene = (this as any).scene as THREE.Scene;
+          const renderer = (this as any).renderer as THREE.WebGLRenderer;
+          camera.projectionMatrix = new THREE.Matrix4().fromArray(matrix);
+          renderer.resetState();
+          renderer.render(scene, camera);
+        }
+      };
+      map!.addLayer(customLayer);
+      layerReady = true;
+      loadBuildings(get(shapeStore));
+    });
+
+    const unsubShape = shapeStore.subscribe((shape) => {
+      if (!layerReady) return;
+      if (fetchTimer) clearTimeout(fetchTimer);
+      fetchTimer = setTimeout(() => loadBuildings(shape), 300);
     });
 
     return () => {
+      unsubShape();
       mapStore.set(undefined);
       map?.remove();
     };

--- a/todo.md
+++ b/todo.md
@@ -135,3 +135,4 @@ Die bestehende GLTFExporter-Logik kann beibehalten werden. Sie exportiert die ge
 [x] Feature: Shape-Selector für Rechtecke und Kreise
 [x] Feature: Overpass-Abfrage für gezeichnete Polygone
 [x] Feature: STL-Export
+[x] Feature: Gebäudeextrusion auf der Karte


### PR DESCRIPTION
## Summary
- render extruded building meshes on the map using a Three.js custom layer
- fetch model data for drawn shapes via `/api/model`
- document building extrusion feature

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_6892398c5624832a84052d7b76f94095