### PR TITLE
feat: expand model controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ und dieses Projekt verwendet [SemVer](https://semver.org/lang/de/) für die Vers
 - Export von Modellen als GLTF, GLB und STL mit Dateinamenvorschlag und Nutzerfeedback
 - Gebäudeextrusionen direkt auf der Karte
 - Export der Kartenextrusion als STL oder 3MF
+- Erweiterte ModelControls für Basishöhe, Gebäudehöhen-Multiplikator bis 5x und Layer-Filter mit Flächenlimit
 
 ---
 

--- a/api.md
+++ b/api.md
@@ -10,7 +10,8 @@ Generates simplified 3D geometry from OpenStreetMap data.
   "scale": number,
   "baseHeight": number,             // optional (default 0)
   "buildingMultiplier": number,     // optional (default 1)
-  "elements": ["buildings", "roads", "water"],
+  "minArea": number,                // optional (default 0)
+  "elements": ["buildings", "roads", "water", "green"],
   "bbox": [south, west, north, east] // optional bounding box
 }
 ```
@@ -21,7 +22,7 @@ Generates simplified 3D geometry from OpenStreetMap data.
   "features": [
     {
       "id": number,
-      "type": "building" | "road" | "water",
+      "type": "building" | "road" | "water" | "green",
       "geometry": [ [x, y, z], ... ],
       "height": number
     }

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -99,7 +99,8 @@
           elements: ['buildings'],
           scale: 1,
           baseHeight: cfg.baseHeight,
-          buildingMultiplier: cfg.buildingHeightMultiplier,
+          buildingMultiplier: cfg.buildingMultiplier,
+          minArea: cfg.excludeSmallBuildings ? cfg.minBuildingArea : undefined,
           bbox
         })
       });
@@ -150,7 +151,7 @@
           renderer.render(scene, camera);
         }
       };
-      map!.addLayer(customLayer);
+      map!.addLayer(customLayer as any);
       layerReady = true;
       loadBuildings(get(shapeStore));
     });
@@ -160,9 +161,15 @@
       if (fetchTimer) clearTimeout(fetchTimer);
       fetchTimer = setTimeout(() => loadBuildings(shape), 300);
     });
+    const unsubCfg = modelConfigStore.subscribe(() => {
+      if (!layerReady) return;
+      if (fetchTimer) clearTimeout(fetchTimer);
+      fetchTimer = setTimeout(() => loadBuildings(get(shapeStore)), 300);
+    });
 
     return () => {
       unsubShape();
+      unsubCfg();
       mapStore.set(undefined);
       extrudeGroupStore.set(null);
       map?.remove();

--- a/src/lib/components/MapExport.svelte
+++ b/src/lib/components/MapExport.svelte
@@ -29,7 +29,8 @@
     }
     const exporter = new STLExporter();
     const result = exporter.parse(group, { binary: true }) as DataView;
-    const blob = new Blob([result.buffer], { type: 'model/stl' });
+    const buffer = result.buffer as ArrayBuffer;
+    const blob = new Blob([buffer], { type: 'model/stl' });
     downloadBlob(blob, 'stl');
   }
 

--- a/src/lib/components/ModelControls.svelte
+++ b/src/lib/components/ModelControls.svelte
@@ -6,19 +6,23 @@
 
   let scale = 500;
   let baseHeight = 0;
-  let buildingHeightMultiplier = 1;
+  let buildingMultiplier = 1;
   let elements = {
     buildings: true,
     roads: true,
     water: true,
     green: true
   };
+  let excludeSmallBuildings = false;
+  let minBuildingArea = 50;
 
   const unsubscribe = modelConfigStore.subscribe((value) => {
     scale = value.scale;
     baseHeight = value.baseHeight;
-    buildingHeightMultiplier = value.buildingHeightMultiplier;
+    buildingMultiplier = value.buildingMultiplier;
     elements = { ...value.elements };
+    excludeSmallBuildings = value.excludeSmallBuildings;
+    minBuildingArea = value.minBuildingArea;
   });
 
   onDestroy(unsubscribe);
@@ -27,15 +31,17 @@
     modelConfigStore.set({
       scale,
       baseHeight,
-      buildingHeightMultiplier,
-      elements: { ...elements }
+      buildingMultiplier,
+      elements: { ...elements },
+      excludeSmallBuildings,
+      minBuildingArea
     });
   }
 </script>
 
 <div class="space-y-4">
   <div>
-    <label class="block text-sm font-medium mb-1" for="scaleSelect">Maßstab</label>
+    <label class="block text-sm font-medium mb-1" for="scaleSelect" title="Maßstab des Modells">Maßstab</label>
     <select
       id="scaleSelect"
       class="w-full border p-1"
@@ -49,7 +55,7 @@
   </div>
 
   <div>
-    <label class="block text-sm font-medium mb-1" for="baseHeight">Basishöhe (m)</label>
+    <label class="block text-sm font-medium mb-1" for="baseHeight" title="Versenkt oder hebt das Modell an">Basishöhe (m)</label>
     <input
       id="baseHeight"
       type="number"
@@ -65,16 +71,17 @@
     <label
       class="block text-sm font-medium mb-1"
       for="heightMultiplier"
-      >Gebäudehöhe-Multiplikator: {buildingHeightMultiplier}</label
+      title="Skaliert die Gebäudehöhen"
+      >Gebäudehöhe-Multiplikator: {buildingMultiplier.toFixed(1)}x</label
     >
     <input
       id="heightMultiplier"
       type="range"
       min="0.5"
-      max="3"
+      max="5"
       step="0.1"
       class="w-full"
-      bind:value={buildingHeightMultiplier}
+      bind:value={buildingMultiplier}
       on:input={updateStore}
     />
   </div>
@@ -113,6 +120,22 @@
           on:change={updateStore}
         />
         <span>Grünflächen</span>
+      </label>
+      <label class="flex items-center space-x-2" title="Blendet kleine Gebäude aus">
+        <input
+          type="checkbox"
+          bind:checked={excludeSmallBuildings}
+          on:change={updateStore}
+        />
+        <span>Gebäude unter</span>
+        <input
+          type="number"
+          class="w-16 border p-1 text-xs"
+          min="0"
+          bind:value={minBuildingArea}
+          on:input={updateStore}
+        />
+        <span>m² ausschließen</span>
       </label>
     </div>
   </fieldset>

--- a/src/lib/stores/modelConfigStore.ts
+++ b/src/lib/stores/modelConfigStore.ts
@@ -10,18 +10,22 @@ export interface ModelElements {
 export interface ModelConfig {
   scale: number;
   baseHeight: number;
-  buildingHeightMultiplier: number;
+  buildingMultiplier: number;
   elements: ModelElements;
+  excludeSmallBuildings: boolean;
+  minBuildingArea: number;
 }
 
 export const modelConfigStore = writable<ModelConfig>({
   scale: 500,
   baseHeight: 0,
-  buildingHeightMultiplier: 1,
+  buildingMultiplier: 1,
   elements: {
     buildings: true,
     roads: true,
     water: true,
     green: true
-  }
+  },
+  excludeSmallBuildings: false,
+  minBuildingArea: 50
 });

--- a/src/lib/stores/modelStore.ts
+++ b/src/lib/stores/modelStore.ts
@@ -24,7 +24,8 @@ async function loadModel() {
       body: JSON.stringify({
         scale: cfg.scale,
         baseHeight: cfg.baseHeight,
-        buildingMultiplier: cfg.buildingHeightMultiplier,
+        buildingMultiplier: cfg.buildingMultiplier,
+        minArea: cfg.excludeSmallBuildings ? cfg.minBuildingArea : undefined,
         elements,
         bbox: shape ? undefined : bbox || undefined,
         shape: shape || undefined

--- a/src/lib/utils/convertTo3D.ts
+++ b/src/lib/utils/convertTo3D.ts
@@ -4,7 +4,7 @@ export type SimplePolygon = [number, number, number][];
 export interface Feature {
   geometry: SimplePolygon | SimplePolygon[];
   height: number;
-  type: 'building' | 'road' | 'water';
+  type: 'building' | 'road' | 'water' | 'green' | 'other';
 }
 
 export interface MeshFeature {
@@ -24,6 +24,7 @@ export function convertTo3D(features: Feature[], baseHeight: number): MeshFeatur
   for (const f of features) {
     const polys = toPolygons(f.geometry);
     for (const poly of polys) {
+      if (f.type === 'other') continue;
       const pts = poly.map(([x, _y, z]) => new THREE.Vector2(x, z));
       if (pts.length < 3) continue;
       if (!pts[0].equals(pts[pts.length - 1])) pts.push(pts[0]);

--- a/src/routes/api/model/+server.ts
+++ b/src/routes/api/model/+server.ts
@@ -85,6 +85,7 @@ export const POST: RequestHandler = async ({ request }) => {
     scale,
     baseHeight = 0,
     buildingMultiplier = 1,
+    minArea = 0,
     elements,
     bbox,
     shape,
@@ -104,6 +105,7 @@ export const POST: RequestHandler = async ({ request }) => {
     scale,
     baseHeight,
     buildingMultiplier,
+    minArea,
     elements,
     bbox,
     shape: polygon
@@ -137,7 +139,7 @@ export const POST: RequestHandler = async ({ request }) => {
     });
   }
 
-  const result = convertTo3D(osmData, scale, baseHeight, buildingMultiplier);
+  const result = convertTo3D(osmData, scale, baseHeight, buildingMultiplier, minArea);
   CACHE.set(cacheKey, result);
   saveCache();
   return new Response(JSON.stringify(result), {

--- a/src/routes/api/model/server.test.ts
+++ b/src/routes/api/model/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildOverpassQuery } from '../../../lib/server/overpass';
 import { parsePolygon } from '../../../lib/server/polygon';
-import { convertTo3D } from '../../../lib/utils/convertTo3D';
+import { convertTo3D, type Feature } from '../../../lib/utils/convertTo3D';
 import * as THREE from 'three';
 
 describe('parsePolygon', () => {
@@ -31,10 +31,11 @@ describe('parsePolygon', () => {
 
 describe('buildOverpassQuery', () => {
   it('builds query with bbox and elements', () => {
-    const query = buildOverpassQuery(['buildings', 'roads', 'water'], [1, 2, 3, 4]);
+    const query = buildOverpassQuery(['buildings', 'roads', 'water', 'green'], [1, 2, 3, 4]);
     expect(query).toContain('way["building"](1,2,3,4);relation["building"](1,2,3,4);');
     expect(query).toContain('way["highway"](1,2,3,4);');
     expect(query).toContain('way["natural"="water"](1,2,3,4);relation["natural"="water"](1,2,3,4);');
+    expect(query).toContain('way["leisure"="park"](1,2,3,4);');
     expect(query.trim().endsWith('out geom;')).toBe(true);
   });
 
@@ -56,7 +57,7 @@ describe('buildOverpassQuery', () => {
 
 describe('convertTo3D', () => {
   it('creates extruded meshes from features', () => {
-    const features = [
+    const features: Feature[] = [
       {
         geometry: [
           [0, 0, 0],

--- a/todo.md
+++ b/todo.md
@@ -86,7 +86,7 @@ Die Koordinaten des gezeichneten Pfades werden reaktiv in einem Svelte Store ges
 
 Phase 3: Erweiterte 3D-Generierung & API
 
-[ ] Erweiterung des UI für 3D-Modellierungsoptionen (ModelControls.svelte).
+[x] Erweiterung des UI für 3D-Modellierungsoptionen (ModelControls.svelte).
 
 Implementiere UI-Elemente für die folgenden Parameter:
 


### PR DESCRIPTION
## Summary
- extend model configuration with base height, building multiplier up to 5x and small-building filter
- allow toggling water, road, green layers and rebuild 3D model on change
- support green areas and min-area filtering in Overpass API

## Testing
- `npm run check`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install` and install OS deps)*

------
https://chatgpt.com/codex/tasks/task_e_68924e76a2d0832aa2b22f54f9a9b70d