### PR TITLE
feat(three): add SSR-safe mergeBufferGeometries wrapper and inline three utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ und dieses Projekt verwendet [SemVer](https://semver.org/lang/de/) für die Vers
 - Playwright-E2E-Tests für GPX-Upload, Pfadeditor und Viewer
 - Vitest-Setupdatei zur korrekten Renderung von SvelteKit-Komponenten
 - Dokumentation: CODEMAP mit Architektur und Datenflüssen
+- SSR-sicherer Wrapper für `mergeBufferGeometries` inkl. Basis-Tests
+
+### Fixed
+- ESM/SSR-Importprobleme bei `three` durch Inline-Konfiguration in Vite/Vitest
 
 ---
 

--- a/src/lib/components/Viewer.svelte
+++ b/src/lib/components/Viewer.svelte
@@ -2,7 +2,7 @@
   import * as THREE from 'three';
   import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
   import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
-  import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+    import { mergeBufferGeometries } from '$lib/three/geometry';
   import * as exportSTL from 'threejs-export-stl';
   import { exportTo3MF as export3MF } from 'three-3mf-exporter';
   import { onMount } from 'svelte';

--- a/src/lib/three/geometry.test.ts
+++ b/src/lib/three/geometry.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { mergeBufferGeometries } from '$lib/three/geometry';
+
+describe('mergeBufferGeometries wrapper', () => {
+  it('should be a function', () => {
+    expect(typeof mergeBufferGeometries).toBe('function');
+  });
+
+  it('should throw when given an empty array', () => {
+    expect(() => mergeBufferGeometries([], true)).toThrow();
+  });
+});

--- a/src/lib/three/geometry.ts
+++ b/src/lib/three/geometry.ts
@@ -1,0 +1,33 @@
+// Einheitlicher Zugriff auf mergeBufferGeometries – stabil in Dev, SSR, Tests.
+// Versucht zuerst benannten Export, fällt sonst auf Namespace-Import zurück.
+
+let _mergeBufferGeometries: ((geoms: any[], useGroups?: boolean) => any) | null = null;
+
+try {
+  const mod = await import('three/examples/jsm/utils/BufferGeometryUtils.js');
+  if (mod && typeof (mod as any).mergeBufferGeometries === 'function') {
+    _mergeBufferGeometries = (mod as any).mergeBufferGeometries;
+  }
+} catch {}
+
+if (!_mergeBufferGeometries) {
+  try {
+    const ns = await import('three/examples/jsm/utils/BufferGeometryUtils.js');
+    const fn =
+      (ns && (ns as any).mergeBufferGeometries) ||
+      (ns && (ns as any).default && (ns as any).default.mergeBufferGeometries);
+    if (typeof fn === 'function') _mergeBufferGeometries = fn;
+  } catch {}
+}
+
+export function mergeBufferGeometries(geoms: any[], useGroups = false) {
+  if (!_mergeBufferGeometries) {
+    throw new Error(
+      "[three] mergeBufferGeometries nicht verfügbar. " +
+        "Stelle sicher, dass 'three' installiert ist und den benannten Export liefert. " +
+        'Alternativ: three updaten oder Utils-Datei vendoren.'
+    );
+  }
+  return _mergeBufferGeometries(geoms, useGroups);
+}
+

--- a/todo.md
+++ b/todo.md
@@ -143,3 +143,4 @@ Die bestehende GLTFExporter-Logik kann beibehalten werden. Sie exportiert die ge
 [x] Playwright E2E-Tests für GPX-Upload, Pfadeditor und Viewer
 [x] Feature: STL-/3MF-Export-Buttons mit Toast-Bestätigung
 [x] Codebasiskarte erstellt
+[x] Fix: SSR-sicherer Wrapper für mergeBufferGeometries

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,11 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+  plugins: [sveltekit()],
+  optimizeDeps: {
+    include: ['three', 'three/examples/jsm/utils/BufferGeometryUtils.js'],
+  },
+  ssr: {
+    noExternal: ['three'],
+  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     environment: 'jsdom',
     globals: true,
-    setupFiles: ['vitest.setup.ts']
+    setupFiles: ['vitest.setup.ts'],
+    deps: {
+      inline: ['three', 'three/examples/jsm/utils/BufferGeometryUtils.js'],
+    },
   }
 });


### PR DESCRIPTION
## Summary
- add robust mergeBufferGeometries wrapper with SSR-safe dynamic imports
- inline three and BufferGeometryUtils in vite/vitest configs for SSR/ESM
- add basic unit test for wrapper

## Testing
- `npm test` (fails: browserType.launch: Executable doesn't exist / missing dependencies)
- `npx playwright test` (fails: browserType.launch: Executable doesn't exist / missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68958eeb760c832ab5352d9cd480e50f