### PR TITLE
chore(ci): add GHCR release workflow and docker docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*.*.*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
+      - name: Install deps
+        run: npm ci
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Unit tests
+        run: npm test
+
+  docker:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Determine tags
+        id: meta
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tags=${{ env.IMAGE_NAME }}:${VERSION},${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          else
+            echo "tags=${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          fi
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [ docker ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          awk "/## \\[${TAG}\\]/{flag=1;next}/^## \\[/{flag=0}flag" CHANGELOG.md > RELEASE_NOTES.md || true
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "No specific notes found; using Unreleased section or fallback."
+            awk '/## \\[Unreleased\\]/{flag=1;next}/^## \\[/{flag=0}flag' CHANGELOG.md > RELEASE_NOTES.md || true
+          fi
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: RELEASE_NOTES.md
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ und dieses Projekt verwendet [SemVer](https://semver.org/lang/de/) für die Vers
 - Tile-Splitting für große Gebiete inklusive Deduplizierung und Debug-Metadaten
 - Höhenprofil für Routen inkl. Geländeauffahrung und OSM-Korridor
 - Farbpaletten für Gebäude-/Flächentypen inkl. Legende und Hover-Infos
+- GitHub Actions Workflow für Docker-Builds und Releases nach GHCR
+- Dokumentation zum Ausführen des Containers via Docker
 
 ### Fixed
 - ESM/SSR-Importprobleme bei `three` durch Inline-Konfiguration in Vite/Vitest

--- a/README.md
+++ b/README.md
@@ -40,6 +40,31 @@ npx playwright install --with-deps
 docker compose up --build
 ```
 
+#### Run via Docker
+
+- Pull:
+
+```bash
+docker pull ghcr.io/ToDiii/3dmap:latest
+```
+
+- Start:
+
+```bash
+docker run -p 3000:3000 \
+  -e OVERPASS_ENDPOINTS="https://overpass-api.de/api/interpreter" \
+  -e ROUTING_PROVIDER=openrouteservice -e ROUTING_API_KEY=sk_xxx \
+  -e GEOCODE_PROVIDER=nominatim \
+  -e ELEVATION_PROVIDER=opentopodata \
+  ghcr.io/ToDiii/3dmap:latest
+```
+
+- Optional: Volume für Cache
+
+```bash
+-v $(pwd)/model-cache.json:/app/model-cache.json
+```
+
 ### 🧪 Tests
 
 #### Unit-Tests (z. B. Overpass-Abfrage, 3D-Konvertierung)

--- a/todo.md
+++ b/todo.md
@@ -149,3 +149,4 @@ Die bestehende GLTFExporter-Logik kann beibehalten werden. Sie exportiert die ge
 [x] Overpass-Robustheit & Tile-Splitting
 [x] Feature: Höhenprofil & Routenkorridor
 [x] Feature: Thematische Schemata, Legende und Hover-Infos
+[x] CI/CD: Docker-Build & Release-Workflow über GHCR


### PR DESCRIPTION
## Summary
- add release workflow to build & publish Docker images to GHCR and create GitHub releases
- document how to run the application via GHCR Docker image
- track release workflow work in TODO and changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41c882730832ab629da5150781e3d