### PR TITLE
fix: default-import lz-string and guard browser APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ und dieses Projekt verwendet [SemVer](https://semver.org/lang/de/) für die Vers
 - ESM/SSR-Importprobleme bei `three` durch Inline-Konfiguration in Vite/Vitest
 - GHCR release workflow uses lowercase image tags to satisfy registry requirements
 - Replaced PNG PWA icons with SVG placeholders to avoid binary files
+- Fix: lz-string SSR default import; removed direct lz-string imports in components
+- Fix: Removed invalid ErrorBoundary usage; added SvelteKit +error.svelte; favicon link now points to generated PNG
 
 ---
 

--- a/scripts/generate-icons.mjs
+++ b/scripts/generate-icons.mjs
@@ -5,7 +5,7 @@ import sharp from 'sharp';
 const SRC = 'static/icons/app.svg';
 const OUT = 'static/icons-gen';
 
-const sizes = [48,72,96,128,144,152,180,192,256,384,512];
+const sizes = [32,48,72,96,128,144,152,180,192,256,384,512];
 
 async function ensureDir(dir) {
   await fs.mkdir(dir, { recursive: true });

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,6 +3,6 @@ import '$lib/telemetry/sentry.server';
 import * as Sentry from '@sentry/sveltekit';
 
 export const handleError: HandleServerError = ({ error, event }) => {
-  Sentry.captureException(error, { extra: { event } });
+  Sentry.captureException(error, { tags: { path: event.url.pathname } });
   return { message: 'Internal Server Error' };
 };

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -187,7 +187,7 @@
         }
       });
       const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false });
-      map.on('mousemove', (e) => {
+      map!.on('mousemove', (e) => {
         const feats = map!.queryRenderedFeatures(e.point, {
           layers: ['extrude-buildings', 'model-water', 'model-green']
         });

--- a/src/lib/components/ShareLink.svelte
+++ b/src/lib/components/ShareLink.svelte
@@ -2,10 +2,12 @@
   import { collectCurrentState } from '$lib/state/bridge';
   import { serialize, MAX_STATE_SIZE } from '$lib/state/serialize';
   import { writeToUrl } from '$lib/state/url';
+  import { browser } from '$app/environment';
   let notice: string | null = null;
   let length = 0;
 
   async function copyLink() {
+    if (!browser) return;
     const s = serialize(collectCurrentState());
     length = s.length;
     writeToUrl(s, true);

--- a/src/lib/components/Viewer.svelte
+++ b/src/lib/components/Viewer.svelte
@@ -88,15 +88,16 @@
   ) {
     clearGroup(pathGroup, true);
     if (!p || p.coordinates.length < 2) return;
+    const coords = p.coordinates as [number, number][];
     const pts: THREE.Vector3[] = [];
     const grades: number[] = [];
-    for (let i = 0; i < p.coordinates.length; i++) {
-      const [lon, lat] = p.coordinates[i];
+    for (let i = 0; i < coords.length; i++) {
+      const [lon, lat] = coords[i];
       const elev = elevations?.[i] ?? 0;
       pts.push(new THREE.Vector3(lon * scale, baseHeight + elev + 0.1, lat * scale));
-      if (i < p.coordinates.length - 1) {
+      if (i < coords.length - 1) {
         const elev2 = elevations?.[i + 1] ?? elev;
-        const dist = haversine(p.coordinates[i], p.coordinates[i + 1]);
+        const dist = haversine(coords[i], coords[i + 1]);
         const grade = dist === 0 ? 0 : (elev2 - elev) / dist;
         grades.push(grade);
       }

--- a/src/lib/controls/shortcuts.ts
+++ b/src/lib/controls/shortcuts.ts
@@ -7,6 +7,7 @@ import { resetProject } from '$lib/utils/projectIO';
 import { collectCurrentState } from '$lib/state/bridge';
 import { serialize } from '$lib/state/serialize';
 import { writeToUrl } from '$lib/state/url';
+import { browser } from '$app/environment';
 
 export interface Shortcut {
   id: string;
@@ -154,6 +155,7 @@ function buildRegistry(): Shortcut[] {
       combo: 'Mod+Shift+L',
       group: 'Projekt',
       run: async () => {
+        if (!browser) return;
         const s = serialize(collectCurrentState());
         writeToUrl(s, true);
         await navigator.clipboard.writeText(location.href);

--- a/src/lib/geo/buffer.ts
+++ b/src/lib/geo/buffer.ts
@@ -8,5 +8,5 @@ export function bufferLine(
 ): GeoJSON.Polygon {
   const feat = lineString(line.coordinates);
   const buf = buffer(feat, meters, { units: 'meters' });
-  return buf.geometry as GeoJSON.Polygon;
+  return buf!.geometry as GeoJSON.Polygon;
 }

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,11 +1,12 @@
 import { writable } from 'svelte/store';
 import { Workbox } from 'workbox-window';
+import { browser } from '$app/environment';
 
 export const updateAvailable = writable(false);
 let wb: Workbox | null = null;
 
 export function initPWA() {
-  if ('serviceWorker' in navigator) {
+  if (browser && 'serviceWorker' in navigator) {
     wb = new Workbox('/service-worker.js');
     wb.addEventListener('waiting', () => {
       updateAvailable.set(true);
@@ -20,5 +21,6 @@ export function initPWA() {
 }
 
 export function skipWaiting() {
+  if (!browser) return;
   wb?.messageSkipWaiting();
 }

--- a/src/lib/services/elevation.ts
+++ b/src/lib/services/elevation.ts
@@ -96,7 +96,7 @@ export function densifyLine(
   line: GeoJSON.LineString,
   targetSamples: number
 ): Array<[number, number]> {
-  const coords = line.coordinates;
+  const coords = line.coordinates as [number, number][];
   if (coords.length >= targetSamples) return coords.slice();
   const distances: number[] = [0];
   for (let i = 1; i < coords.length; i++) {

--- a/src/lib/state/bridge.ts
+++ b/src/lib/state/bridge.ts
@@ -89,17 +89,18 @@ export async function applyState(scene: SceneState): Promise<void> {
     }
   });
 
-  if (scene.layers) layerStore.set(scene.layers);
+    if (scene.layers)
+      layerStore.set({ buildings3d: true, water: true, green: true, ...scene.layers });
 
   if (scene.shape) {
-    if ('bbox' in scene.shape) {
-      const [west, south, east, north] = scene.shape.bbox;
-      bboxStore.set([south, west, north, east]);
-      shapeStore.set(null);
-    } else {
-      shapeStore.set(scene.shape);
-      bboxStore.set(null);
-    }
+      if ('bbox' in scene.shape && scene.shape.bbox) {
+        const [west, south, east, north] = scene.shape.bbox;
+        bboxStore.set([south, west, north, east]);
+        shapeStore.set(null);
+      } else {
+        shapeStore.set(scene.shape as GeoJSON.Polygon);
+        bboxStore.set(null);
+      }
   }
 
   if (scene.route) {

--- a/src/lib/state/serialize.test.ts
+++ b/src/lib/state/serialize.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { serialize, deserialize, MAX_STATE_SIZE } from './serialize';
 import type { SceneState } from './schema';
-import { compressToEncodedURIComponent } from 'lz-string';
+import LZString from 'lz-string';
+const { compressToEncodedURIComponent } = LZString;
 
 describe('state serialization', () => {
   const baseState: SceneState = {

--- a/src/lib/state/serialize.ts
+++ b/src/lib/state/serialize.ts
@@ -1,4 +1,8 @@
-import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+import LZString from 'lz-string';
+const {
+  compressToEncodedURIComponent,
+  decompressFromEncodedURIComponent
+} = LZString;
 import type { SceneState } from './schema';
 import { STATE_VERSION } from './schema';
 

--- a/src/lib/state/url.ts
+++ b/src/lib/state/url.ts
@@ -1,6 +1,9 @@
+import { browser } from '$app/environment';
+
 const PREFIX = '#s=';
 
 export function writeToUrl(stateStr: string, replace = true): void {
+  if (!browser) return;
   const hash = PREFIX + stateStr;
   if (replace) {
     history.replaceState(null, '', hash);
@@ -10,11 +13,13 @@ export function writeToUrl(stateStr: string, replace = true): void {
 }
 
 export function readFromUrl(): string | null {
+  if (!browser) return null;
   const h = location.hash;
   if (h.startsWith(PREFIX)) return h.slice(PREFIX.length);
   return null;
 }
 
 export function clearFromUrl(): void {
+  if (!browser) return;
   history.replaceState(null, '', ' ');
 }

--- a/src/lib/telemetry/sentry.client.ts
+++ b/src/lib/telemetry/sentry.client.ts
@@ -10,7 +10,7 @@ import {
 } from '$lib/config/env';
 import { settingsStore } from '$lib/stores/settingsStore';
 
-export function scrubEvent(event: Sentry.Event): Sentry.Event | null {
+export function scrubEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
   if (event.request?.url) {
     try {
       const u = new URL(event.request.url);
@@ -35,7 +35,7 @@ function init() {
     tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
     denyUrls: [/tile/, /cdn/],
     beforeSend(event) {
-      return scrubEvent(event);
+      return scrubEvent(event as Sentry.ErrorEvent);
     }
   });
 }

--- a/src/lib/telemetry/sentry.test.ts
+++ b/src/lib/telemetry/sentry.test.ts
@@ -8,12 +8,12 @@ describe('scrubEvent', () => {
       user: { email: 'a@b.com' }
     };
     const res = scrubEvent(event)!;
-    expect(res.request.url).toBe('https://example.com/x');
+    expect(res.request?.url).toBe('https://example.com/x');
     expect(res.user).toBeUndefined();
   });
   it('rounds coordinates', () => {
     const event: any = { request: { url: 'https://ex.com/10.12345,5.98765' } };
     const res = scrubEvent(event)!;
-    expect(res.request.url).toBe('https://ex.com/10.12,5.99');
+    expect(res.request?.url).toBe('https://ex.com/10.12,5.99');
   });
 });

--- a/src/lib/telemetry/vitals.ts
+++ b/src/lib/telemetry/vitals.ts
@@ -1,4 +1,4 @@
-import { onCLS, onFID, onLCP, onINP } from 'web-vitals';
+import { onCLS, onLCP, onINP } from 'web-vitals';
 import * as Sentry from '@sentry/sveltekit';
 import { settingsStore } from '$lib/stores/settingsStore';
 import { TELEMETRY_ENABLED, SENTRY_DSN } from '$lib/config/env';
@@ -21,13 +21,11 @@ export function initWebVitals() {
   if (!(TELEMETRY_ENABLED && SENTRY_DSN && consent)) {
     const log = (m: any) => console.info('web-vital', m);
     onCLS(log);
-    onFID(log);
     onLCP(log);
     onINP(log);
     return;
   }
   onCLS(send);
-  onFID(send);
   onLCP(send);
   onINP(send);
 }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { dev } from '$app/environment';
+export let status: number;
+export let error: Error;
+function reload() { location.reload(); }
+</script>
+
+<svelte:head>
+  <title>{status} – Fehler</title>
+</svelte:head>
+
+<main class="error-page">
+  <h1>{status}</h1>
+  <p>{error.message}</p>
+  {#if dev && error.stack}
+    <pre>{error.stack}</pre>
+  {/if}
+  <div class="actions">
+    <button on:click={reload}>Neu laden</button>
+    <a href="/">Zur Karte</a>
+    <a href="https://github.com/3dmap/3dmap/issues" target="_blank" rel="noopener">Fehler melden</a>
+  </div>
+</main>
+
+<style>
+  .error-page {
+    max-width: 40rem;
+    margin: 2rem auto;
+    padding: 1rem;
+    text-align: center;
+  }
+  .actions {
+    margin-top: 1rem;
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+  }
+  pre {
+    text-align: left;
+    overflow: auto;
+    background: #f5f5f5;
+    padding: 1rem;
+  }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import '../app.css';
-import favicon from '$lib/assets/favicon.svg';
 import { onMount, onDestroy } from 'svelte';
 import CommandPalette from '$lib/components/CommandPalette.svelte';
 import ShortcutHelp from '$lib/components/ShortcutHelp.svelte';
@@ -19,7 +18,6 @@ import { mapStore } from '$lib/stores/map';
 import { browser } from '$app/environment';
 import { settingsStore } from '$lib/stores/settingsStore';
 import { initWebVitals } from '$lib/telemetry/vitals';
-import { ErrorBoundary } from 'svelte';
 let { children } = $props();
 let removeShortcuts: (() => void) | undefined;
 onMount(async () => {
@@ -64,20 +62,12 @@ function reload() {
 }
 </script>
 <svelte:head>
-<link rel="icon" href={favicon} />
+<link rel="icon" type="image/png" href="/icons-gen/icon-32.png" />
 <link rel="manifest" href="/manifest.webmanifest" />
 <link rel="apple-touch-icon" sizes="180x180" href="/icons-gen/apple-touch-icon-180.png" />
 <meta name="theme-color" content="#111111" />
 </svelte:head>
-<ErrorBoundary let:error>
-  {@render children?.()}
-  <svelte:fragment slot="fallback">
-    <div class="error-boundary">
-      <p>Ein Fehler ist aufgetreten.</p>
-      <button on:click={reload}>Neu laden</button>
-    </div>
-  </svelte:fragment>
-</ErrorBoundary>
+{@render children?.()}
 <CommandPalette />
 <ShortcutHelp />
 {#if $updateAvailable}
@@ -101,14 +91,5 @@ function reload() {
     padding: 0.2rem 0.5rem;
     border: none;
     border-radius: 3px;
-  }
-  .error-boundary {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: #fff;
-    padding: 1rem;
-    border: 1px solid #ccc;
   }
 </style>

--- a/tests/error-page.spec.ts
+++ b/tests/error-page.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ErrorPage from '../src/routes/+error.svelte';
+
+describe('+error.svelte', () => {
+  it('shows status and message', () => {
+    const { getByText } = render(ErrorPage, { props: { status: 500, error: new Error('boom') } });
+    expect(getByText('500')).toBeTruthy();
+    expect(getByText('boom')).toBeTruthy();
+  });
+});

--- a/tests/serialize.spec.ts
+++ b/tests/serialize.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { serialize, deserialize } from '$lib/state/serialize';
+
+describe('serialize/deserialize', () => {
+  it('roundtrips without SSR import errors', () => {
+    const state = {
+      v: 1,
+      model: { scale: 1000, baseHeight: 0, buildingMultiplier: 1, elementTypes: ['building'] },
+      view: { map: { center: [11.5761, 48.1372], zoom: 14 }, mode: 'map' },
+      layers: { buildings3d: true, water: true, green: true }
+    } as any;
+    const s = serialize(state);
+    const back = deserialize(s)!;
+    expect(back.v).toBe(1);
+    expect(back.model.scale).toBe(1000);
+  });
+});
+

--- a/todo.md
+++ b/todo.md
@@ -155,3 +155,5 @@ Die bestehende GLTFExporter-Logik kann beibehalten werden. Sie exportiert die ge
 [x] Feature: Szenenstate als komprimierten Permalink teilen
 [x] Feature: Tastatur-Shortcuts & Command Palette
 [x] Feature: Optionale Telemetrie (Sentry) und Web-Vitals
+[x] Permalink SSR-Fix
+[x] Error-Flow stabilisieren / ErrorBoundary entfernen


### PR DESCRIPTION
## Summary
- use default import for `lz-string` to avoid SSR named-import errors
- route serialization through `$lib/state/serialize`, guard browser APIs, and remove obsolete `ErrorBoundary`
- add global `+error.svelte`, generate 32px favicon and document error-flow fix
- resolve type issues in telemetry and geometry code and drop deprecated `onFID` metric

## Testing
- `npm run check`
- `npm test`
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68a4977520ac832ab27464f457c3022e