### PR TITLE
Sync viewer path geometry with configurable path style

### DIFF
--- a/src/lib/project/importers/map2model.test.ts
+++ b/src/lib/project/importers/map2model.test.ts
@@ -114,11 +114,13 @@ describe('map2model importer', () => {
 		expect(get(uiConfigStore).frame.enabled).toBe(true);
 		expect(get(colorPalette).road).toBe('#111');
 		expect(get(colorPalette).buildingResidential).toBe('#444');
-		expect(get(colorPalette).buildingCommercial).toBe('#444');
-		expect(get(colorPalette).buildingIndustrial).toBe('#444');
-		expect(get(pathStore)).toEqual(proj.generatorOptions.gpxPathGeoJSON);
-		expect(get(pathStyleStore).widthMeters).toBe(2);
-	});
+                expect(get(colorPalette).buildingCommercial).toBe('#444');
+                expect(get(colorPalette).buildingIndustrial).toBe('#444');
+                expect(get(pathStore)).toEqual(proj.generatorOptions.gpxPathGeoJSON);
+                expect(get(pathStyleStore).color).toBe('#ff0000');
+                expect(get(pathStyleStore).widthMeters).toBe(2);
+                expect(get(pathStyleStore).heightMM).toBe(1);
+        });
 
 	it('updates legend colors after importing a palette', async () => {
 		const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- subscribe to the path style store in the 3D viewer to size the tube geometry by the configured width and height, switch between slope gradient and solid colour materials, and rebuild geometry before exports
- drive the map route layer paint properties from the path style store so colour and width react to updates via `setPaintProperty`
- extend the Map2Model importer test to cover propagation of path style colour, width and height

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbb69e4ca4832aa5e62f09a3b0b2ed