### PR TITLE
Sync viewer path geometry with configurable path style

### DIFF
--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -10,6 +10,7 @@
 	import { modelError } from '$lib/stores/modelStore';
 	import { pathStore } from '$lib/stores/pathStore';
 	import { pathStyleStore } from '$lib/stores/pathStyleStore';
+	import type { PathStyle } from '$lib/stores/pathStyleStore';
 	import * as THREE from 'three';
 	import { getBuildingMaterial, disposeBuildingMaterials } from '$lib/three/materials';
 	import { colorPalette } from '$lib/stores/colorPalette';
@@ -39,6 +40,13 @@
 
 	let palette: ColorPalette = get(colorPalette);
 	let pathStyle = get(pathStyleStore);
+
+	function getRouteLineWidth(style: PathStyle): number {
+		if (style.widthMeters && style.widthMeters > 0) {
+			return Math.max(style.widthMeters, 1);
+		}
+		return 4;
+	}
 
 	function buildingColorExpression(p: ColorPalette) {
 		return [
@@ -73,6 +81,7 @@
 		if (!map) return;
 		if (map.getLayer(routeLayerId)) {
 			map.setPaintProperty(routeLayerId, 'line-color', pathStyle.color);
+			map.setPaintProperty(routeLayerId, 'line-width', getRouteLineWidth(pathStyle));
 		}
 	}
 
@@ -271,7 +280,10 @@
 							id: routeLayerId,
 							type: 'line',
 							source: routeSourceId,
-							paint: { 'line-color': pathStyle.color, 'line-width': 4 },
+							paint: {
+								'line-color': pathStyle.color,
+								'line-width': getRouteLineWidth(pathStyle),
+							},
 						});
 					}
 				} else {

--- a/src/lib/components/Viewer.svelte
+++ b/src/lib/components/Viewer.svelte
@@ -8,6 +8,7 @@
 	import { onMount } from 'svelte';
 	import { modelConfigStore } from '$lib/stores/modelConfigStore';
 	import { pathStore } from '$lib/stores/pathStore';
+	import { pathStyleStore } from '$lib/stores/pathStyleStore';
 	import { modelStore, modelLoading, modelError } from '$lib/stores/modelStore';
 	import { routeStore } from '$lib/stores/routeStore';
 	import { uiConfigStore } from '$lib/stores/uiConfigStore';
@@ -42,6 +43,7 @@
 	let path: GeoJSON.LineString | null = null;
 	let elevations: number[] | undefined;
 	let isLoading = false;
+	let pathStyle = get(pathStyleStore);
 	const raycaster = new THREE.Raycaster();
 	const pointer = new THREE.Vector2();
 	let hoverText: string | null = null;
@@ -96,35 +98,70 @@
 		const coords = p.coordinates as [number, number][];
 		const pts: THREE.Vector3[] = [];
 		const grades: number[] = [];
+		const { widthMeters, heightMM, color } = pathStyle;
+		const baseOffset = Math.max((heightMM ?? 0) / 1000, 0.001);
+		let unitsPerMeter: number | null = null;
 		for (let i = 0; i < coords.length; i++) {
 			const [lon, lat] = coords[i];
 			const elev = elevations?.[i] ?? 0;
-			pts.push(new THREE.Vector3(lon * scale, baseHeight + elev + 0.1, lat * scale));
+			const point = new THREE.Vector3(lon * scale, baseHeight + elev + baseOffset, lat * scale);
+			pts.push(point);
 			if (i < coords.length - 1) {
 				const elev2 = elevations?.[i + 1] ?? elev;
 				const dist = haversine(coords[i], coords[i + 1]);
 				const grade = dist === 0 ? 0 : (elev2 - elev) / dist;
 				grades.push(grade);
+				if (unitsPerMeter === null && dist > 0) {
+					const next = coords[i + 1];
+					const dx = (next[0] - lon) * scale;
+					const dz = (next[1] - lat) * scale;
+					const planar = Math.sqrt(dx * dx + dz * dz);
+					if (planar > 0) {
+						unitsPerMeter = planar / dist;
+					}
+				}
 			}
 		}
 		const segments = pts.length - 1;
 		const radial = 8;
 		const curve = new THREE.CatmullRomCurve3(pts);
-		const geom = new THREE.TubeGeometry(curve, segments, 0.5, radial, false);
-		const colors = new Float32Array((segments + 1) * (radial + 1) * 3);
-		for (let i = 0; i <= segments; i++) {
-			const g = i === segments ? grades[segments - 1] : grades[i];
-			const col = new THREE.Color(interpolateSlopeColor(g));
-			for (let j = 0; j <= radial; j++) {
-				const idx = (i * (radial + 1) + j) * 3;
-				colors[idx] = col.r;
-				colors[idx + 1] = col.g;
-				colors[idx + 2] = col.b;
+		const fallbackUnitsPerMeter = scale > 0 ? 1 / scale : 0;
+		const resolvedUnitsPerMeter =
+			widthMeters > 0
+				? unitsPerMeter || fallbackUnitsPerMeter || 0
+				: unitsPerMeter || fallbackUnitsPerMeter;
+		const rawRadius =
+			widthMeters > 0 && resolvedUnitsPerMeter > 0
+				? (widthMeters * resolvedUnitsPerMeter) / 2
+				: 0.5;
+		const radius = Math.max(rawRadius, 0.01);
+		const geom = new THREE.TubeGeometry(curve, segments, radius, radial, false);
+		const useGradient = widthMeters <= 0 || !color || color === 'gradient';
+		let material: THREE.MeshStandardMaterial;
+		if (useGradient) {
+			const colors = new Float32Array((segments + 1) * (radial + 1) * 3);
+			for (let i = 0; i <= segments; i++) {
+				const g = i === segments ? grades[segments - 1] : grades[i];
+				const col = new THREE.Color(interpolateSlopeColor(g));
+				for (let j = 0; j <= radial; j++) {
+					const idx = (i * (radial + 1) + j) * 3;
+					colors[idx] = col.r;
+					colors[idx + 1] = col.g;
+					colors[idx + 2] = col.b;
+				}
 			}
+			geom.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+			material = new THREE.MeshStandardMaterial({ vertexColors: true });
+		} else {
+			let meshColor: THREE.Color;
+			try {
+				meshColor = new THREE.Color(color);
+			} catch (err) {
+				meshColor = new THREE.Color('#ff524f');
+			}
+			material = new THREE.MeshStandardMaterial({ color: meshColor });
 		}
-		geom.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-		const mat = new THREE.MeshStandardMaterial({ vertexColors: true });
-		const mesh = new THREE.Mesh(geom, mat);
+		const mesh = new THREE.Mesh(geom, material);
 		mesh.userData = { grades };
 		pathGroup.add(mesh);
 		if (!modelGroup.children.includes(pathGroup)) {
@@ -404,6 +441,10 @@
 			elevations = s.elevations;
 			buildPathGeometry(path, currentBaseHeight, currentScale);
 		});
+		const unsubPathStyle = pathStyleStore.subscribe((style) => {
+			pathStyle = style;
+			buildPathGeometry(path, currentBaseHeight, currentScale);
+		});
 
 		window.addEventListener('resize', onResize);
 		renderer.domElement.addEventListener('pointermove', onPointerMove);
@@ -416,6 +457,7 @@
 			unsubError();
 			unsubPath();
 			unsubRoute();
+			unsubPathStyle();
 			window.removeEventListener('resize', onResize);
 			controls.dispose();
 			renderer.dispose();

--- a/src/lib/project/importers/map2model.test.ts
+++ b/src/lib/project/importers/map2model.test.ts
@@ -117,7 +117,9 @@ describe('map2model importer', () => {
 		expect(get(colorPalette).buildingCommercial).toBe('#444');
 		expect(get(colorPalette).buildingIndustrial).toBe('#444');
 		expect(get(pathStore)).toEqual(proj.generatorOptions.gpxPathGeoJSON);
+		expect(get(pathStyleStore).color).toBe('#ff0000');
 		expect(get(pathStyleStore).widthMeters).toBe(2);
+		expect(get(pathStyleStore).heightMM).toBe(1);
 	});
 
 	it('updates legend colors after importing a palette', async () => {


### PR DESCRIPTION
## Summary
- subscribe to the path style store in the 3D viewer to size the tube geometry by the configured width and height, switch between slope gradient and solid colour materials, and rebuild geometry before exports
- drive the map route layer paint properties from the path style store so colour and width react to updates via `setPaintProperty`
- extend the Map2Model importer test to cover propagation of path style colour, width and height

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbb69e4ca4832aa5e62f09a3b0b2ed